### PR TITLE
Escape all html crud in messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,8 @@
               }
           });
           client.subscribe('/messages', function(message) {
-            $('#output').prepend('<p>' + message.name +': ' + message.text + '</p>');
+            var escapedMessage = $("<div>").text(message.text).html();
+            $('#output').prepend('<p>' + message.name +': ' + escapedMessage + '</p>');
             $.titleAlert("New!", {
               requireBlur:true,
               stopOnFocus:true,


### PR DESCRIPTION
Fixes #6 in a fairly brutal way.

You'd obviously want to re-enable images and other fun afterwards.
