### PR TITLE
Fix issue with super keen html linker

### DIFF
--- a/extensions/auto-html.js
+++ b/extensions/auto-html.js
@@ -1,9 +1,9 @@
-var linkRegex = /((https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)/gi;
+var linkRegex = /( |^)((https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)/gi;
 var imageLinkRegex = /(<a[^>]+>)([^<]+\.(png|gif|jpg))<\/a>/gi;
 var roomMeRegex = /( |^)#([A-Za-z0-9_-]+)(?![A-Za-z0-9_\]-])/g;
 
 var linkifyUrls = function(text) {
-    return text.replace(linkRegex, "<a href='$1' target='_blank'>$1</a>");
+    return text.replace(linkRegex, "$1<a href='$2' target='_blank'>$2</a>");
 };
 var imagifyLinks = function(text) {
     return text.replace(imageLinkRegex, "$1<img src='$2' /></a>");


### PR DESCRIPTION
A pasted link now either needs to be at the start of the message or preceded by a space. This should stop html getting mangled.
