### PR TITLE
Add in-memory layer to the redis storage

### DIFF
--- a/storage/redis-messages.js
+++ b/storage/redis-messages.js
@@ -1,24 +1,37 @@
 var CreateMessageStorage = function(redis, messagesToKeep) {
     var roomLife = 3 * 60 * 60 * 24; // 3 days
     messagesToKeep = messagesToKeep || 30;
+    var inMemoryStorage = {};
+
     var loadMessages = function (roomId, callback) {
         var dataStoreId = 'messages.' + roomId;
+        if (inMemoryStorage[dataStoreId]) {
+            callback(inMemoryStorage[dataStoreId]);
+            return;
+        }
         redis.get(dataStoreId, function(err, reply) {
-            callback(JSON.parse(reply) || []);
+            var messages = JSON.parse(reply) || [];
+            inMemoryStorage[dataStoreId] = messages;
+            callback(messages);
         });
         redis.expire(dataStoreId, roomLife);
     };
+
+    var storeMessage = function (roomId, message) {
+        var dataStoreId = 'messages.' + roomId;
+        loadMessages(roomId, function(currentMessages) {
+            currentMessages.unshift(message);
+            var trimmedMessages = currentMessages.slice(0, messagesToKeep);
+            inMemoryStorage[dataStoreId] = trimmedMessages;
+            redis.set(
+                dataStoreId,
+                JSON.stringify(trimmedMessages)
+            );
+        });
+    };
+
     return {
-        "storeMessage": function (roomId, message) {
-            loadMessages(roomId, function(currentMessages) {
-                var dataStoreId = 'messages.' + roomId;
-                currentMessages.unshift(message);
-                redis.set(
-                    dataStoreId,
-                    JSON.stringify(currentMessages.slice(0, messagesToKeep))
-                );
-            });
-        },
+        "storeMessage": storeMessage,
         "loadMessages": loadMessages
     };
 };


### PR DESCRIPTION
Just something I thought of the other day. Basically if the heroku instance has been up in keeps the messages in memory. They will only be loaded from redis when a new room is hit.
