### PR TITLE
Reduced pool of giphy matches to try and ensure more relevant gifs

### DIFF
--- a/extensions/gif-me.js
+++ b/extensions/gif-me.js
@@ -26,7 +26,7 @@ var GifMeExtension = {
             dontSend = true;
             var param = message.data.text.slice(gifMeKeyword.length).trim();
 
-            var url = 'http://api.giphy.com/v1/gifs/search?api_key=dc6zaTOxFJmzC&limit=25&q=' + param;
+            var url = 'http://api.giphy.com/v1/gifs/search?api_key=dc6zaTOxFJmzC&limit=10&q=' + param;
             request({
                 url: url,
                 json: true


### PR DESCRIPTION
@meadsteve have just reduced the pool as we discussed.  Can't use the /random endpoint as it doesn't have rating.
