### PR TITLE
Add play queue object

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -13,6 +13,7 @@ var bayeux = new Faye.NodeAdapter({mount: '/faye', timeout: 5 });
 var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());
+var playQueue = require("./play-queue").new(bayeux.getClient());
 
 var server = http.createServer(function(request, response) {
     request.addListener('end', function() {

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -1,0 +1,58 @@
+var roomQueue = require("./play-queue/room-queue");
+
+var isValidQueueItem = function (item) {
+    return item.data && item.duration && item.requester;
+};
+
+var roomQueueFactory = function() {
+    return roomQueue.new();
+};
+
+var createNew = function(client) {
+    var roomQueues = {};
+
+    var clearEmptyRooms = function () {
+        Object.keys(roomQueues).filter(function (roomName) {
+            return roomQueues[roomName].isEmpty();
+        }).forEach(function (roomName) {
+            delete roomQueues[roomName];
+        });
+    };
+
+    var messageEachRoom = function () {
+        Object.keys(roomQueues).forEach(function (roomName) {
+            var queue = roomQueues[roomName];
+            var playing = queue.tick(Date.now());
+            if (playing) {
+                console.log(roomName);
+                console.log(playing);
+            }
+        });
+    };
+    var tick = function() {
+        clearEmptyRooms();
+        messageEachRoom();
+    };
+
+    // Finds/Creates a queue for the oom then adds the
+    // item.
+    var queueItem = function(room, item) {
+        if (!isValidQueueItem(item)) {
+            return false;
+        }
+        if (!roomQueues[room]) {
+            roomQueues[room] = roomQueueFactory();
+        }
+        roomQueues[room].add(item);
+        return true;
+    };
+
+    setInterval(tick, 100);
+    return {
+        "queueItem": queueItem
+    };
+};
+
+module.exports = {
+    "new": createNew
+};

--- a/lib/play-queue/room-queue.js
+++ b/lib/play-queue/room-queue.js
@@ -1,0 +1,57 @@
+var validItem = function(item) {
+    return item.data && item.duration && item.requester;
+};
+
+var createNew = function() {
+    var items = [];
+    var playingItem;
+    var changeOverTime = 5000; // 5 seconds between tracks
+
+    var add = function (item) {
+        if (!validItem(item)) {
+            return false;
+        }
+        items.push(item);
+        return true;
+    };
+    var getAll = function () {
+        return items;
+    };
+    var tick = function(currentTime) {
+        // TODO: refactor the slightly complicated logic here
+        var currentOffset;
+        if (playingItem) {
+            currentOffset = currentTime - playingItem.startTime;
+            if (currentOffset > playingItem.duration + changeOverTime) {
+                playingItem = null;
+            } else if(currentOffset > playingItem.duration) {
+                return null;
+            }
+        }
+        if (!playingItem && items.length > 0) {
+            playingItem = items[0];
+            playingItem.startTime = currentTime;
+            items = items.slice(1);
+        }
+        if (playingItem) {
+            currentOffset = currentTime - playingItem.startTime;
+            return {
+                "data":       playingItem.data,
+                "requester":  playingItem.requester,
+                "playOffset": currentOffset
+            };
+        }
+        return null;
+    };
+
+    return {
+        'add'    : add,
+        'getAll' : getAll,
+        'isEmpty': function() { return !playingItem && items.length === 0;},
+        'tick'   : tick
+    };
+};
+
+module.exports = {
+    "new": createNew
+};

--- a/spec/backend/play-queue/room-queue-spec.js
+++ b/spec/backend/play-queue/room-queue-spec.js
@@ -1,0 +1,134 @@
+var roomQueue = require("../../../lib/play-queue/room-queue");
+
+var newExampleItem = function(itemData, itemRequester) {
+    return {
+        "data": itemData,
+        "requester": itemRequester,
+        "duration": 400
+    };
+};
+
+describe("A single room queue that updates when told what the time is", function() {
+    var queue;
+
+    beforeEach(function () {
+        queue = roomQueue.new();
+    });
+
+    it("accepts items given to add", function() {
+        var item = newExampleItem({}, "steve");
+        expect(queue.add(item)).toBe(true);
+    });
+
+    it("queued items are stored", function() {
+        var item =newExampleItem({}, "steve");
+        queue.add(item);
+        expect(queue.getAll()).toEqual([item]);
+    });
+
+    it("can be checked if it's empty", function() {
+        var item =newExampleItem({}, "steve");
+        expect(queue.isEmpty()).toEqual(true);
+        queue.add(item);
+        expect(queue.isEmpty()).toEqual(false);
+        queue.tick(3453495);
+        expect(queue.isEmpty()).toEqual(false);
+    });
+
+    it("when a tick is received the first item in the queue is popped", function() {
+        var first = newExampleItem({}, "steve");
+        var second = newExampleItem({}, "zebra-steve");
+        queue.add(first);
+        queue.add(second);
+
+        queue.tick(Date.now());
+
+        // Only the second item should still be in the queue
+        expect(queue.getAll()).toEqual([second]);
+    });
+
+    it("returns null on ticks on an empty queue", function() {
+        expect(queue.tick(1421092800)).toEqual(null);
+    });
+
+    it("when the first tick is received return data with a play offset of zero", function() {
+        var itemData = {};
+        var itemRequester = "steve";
+        var item = newExampleItem(itemData, itemRequester);
+        queue.add(item);
+
+        var expectedResponse = {
+            "data": itemData,
+            "requester": itemRequester,
+            "playOffset": 0
+        };
+
+        expect(queue.tick(1421092800)).toEqual(expectedResponse);
+    });
+
+    it("updates the play offset on later ticks", function() {
+        var itemData = {};
+        var itemRequester = "steve";
+        var item = newExampleItem(itemData, itemRequester);
+        queue.add(item);
+
+        var startTime = 1421092800;
+        var nextTickDelay = 100;
+        queue.tick(startTime);
+
+        var expectedResponse = {
+            "data": itemData,
+            "requester": itemRequester,
+            "playOffset": nextTickDelay
+        };
+
+        expect(queue.tick(startTime + nextTickDelay)).toEqual(expectedResponse);
+    });
+
+    it("A tick passed the end-time will return null", function() {
+        var itemData = {};
+        var itemRequester = "steve";
+        var item = newExampleItem(itemData, itemRequester);
+        queue.add(item);
+
+        var startTime = 1421092800;
+        var nextTickDelay = 401;
+        queue.tick(startTime);
+
+        var expectedResponse = null;
+
+        expect(queue.tick(startTime + nextTickDelay)).toEqual(expectedResponse);
+    });
+
+    it("After 5 seconds the next queue item is emited on tick ", function() {
+        var itemOneData = {"name": "first"};
+        var itemTwoData = {"name": "second"};
+        var itemRequester = "steve";
+        var itemOne = newExampleItem(itemOneData, itemRequester);
+        var itemTwo = newExampleItem(itemTwoData, itemRequester);
+
+        queue.add(itemOne);
+        queue.add(itemTwo);
+
+        var startTime = 1421092800;
+        var pastFirstduration = 401;
+
+        var expectedFirstResponse = {
+            "data": itemOneData,
+            "requester": itemRequester,
+            "playOffset": 0
+        };
+
+        var expectedThirdResponse = {
+            "data": itemTwoData,
+            "requester": itemRequester,
+            "playOffset": 0
+        };
+
+        expect(queue.tick(startTime)).toEqual(expectedFirstResponse);
+        expect(queue.tick(startTime + pastFirstduration + 1000)).toEqual(null);
+        expect(queue.tick(startTime + pastFirstduration + 3000)).toEqual(null);// still not 5 seconds
+        expect(queue.tick(startTime + pastFirstduration + 5001)).toEqual(expectedThirdResponse);
+    });
+
+});


### PR DESCRIPTION
Fixes #74.

Stores queue for each room.
Every 100 ms console logs for each channel with currently playing data
Queue items with calls like:

``` js
  playQueue.queueItem("fun-room", {data: {'type': "youtube", id: "dfgd84"}, duration: 20000, requester: "steve"});
```

This will need some wiring up once the front end and message listener are ready but it's mostly complete.
