### PR TITLE
Delay server timeout and add ping to keep ws open

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,8 +9,13 @@ var statix = require('node-static'),
     emojiExtension = require("./extensions/emojis");
     youtubeExtension = require("./extensions/youtube-me");
 
+var bayeux = new Faye.NodeAdapter({
+    mount: '/faye',
+    timeout: 45,
+    ping: 20
+});
+
 var dataStore = require("./storage/loader").load(process.env);
-var bayeux = new Faye.NodeAdapter({mount: '/faye', timeout: 5 });
 var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());


### PR DESCRIPTION
May fix #54 

Seems to stop the connection dropping errors running on my test version on heroku. But I think we should keep 54 open until we've been running for a bit and confirmed.
