### PR TITLE
Play queue persistence

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -7,7 +7,8 @@ var statix = require('node-static'),
     messageLogging = require('./extensions/message-logger.js'),
     autoHtmlExtension = require("./extensions/auto-html"),
     emojiExtension = require("./extensions/emojis"),
-    queueMeExtension = require("./extensions/queue-me");
+    queueMeExtension = require("./extensions/queue-me"),
+    storageLoader = require("./storage/loader");
 
 var bayeux = new Faye.NodeAdapter({
     mount: '/faye',
@@ -15,12 +16,12 @@ var bayeux = new Faye.NodeAdapter({
     ping: 20
 });
 
-var dataStore = require("./storage/loader").loadMessageStore(process.env);
+var dataStore = storageLoader.loadMessageStore(process.env);
 var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());
 
-var queueStorage = require("./storage/loader").loadPlayQueueStore(process.env);
+var queueStorage = storageLoader.loadPlayQueueStore(process.env);
 var playQueue = require("./play-queue").new(bayeux.getClient(), queueStorage);
 playQueue.loadPersistedQueues();
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -19,7 +19,9 @@ var dataStore = require("./storage/loader").load(process.env);
 var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());
-var playQueue = require("./play-queue").new(bayeux.getClient());
+
+var queueStorage = require("./storage/null-play-queue").start();
+var playQueue = require("./play-queue").new(bayeux.getClient(), queueStorage);
 playQueue.loadPersistedQueues();
 
 var server = http.createServer(function(request, response) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -15,12 +15,12 @@ var bayeux = new Faye.NodeAdapter({
     ping: 20
 });
 
-var dataStore = require("./storage/loader").load(process.env);
+var dataStore = require("./storage/loader").loadMessageStore(process.env);
 var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());
 
-var queueStorage = require("./storage/null-play-queue").start();
+var queueStorage = require("./storage/loader").loadPlayQueueStore(process.env);
 var playQueue = require("./play-queue").new(bayeux.getClient(), queueStorage);
 playQueue.loadPersistedQueues();
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,6 +20,7 @@ var messageHistoryServer = require("./server/message-history").new(dataStore);
 var fileServer = new(statix.Server)('./www');
 var heartBeat = require("./extensions/heart").new(bayeux.getClient());
 var playQueue = require("./play-queue").new(bayeux.getClient());
+playQueue.loadPersistedQueues();
 
 var server = http.createServer(function(request, response) {
     request.addListener('end', function() {

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -5,7 +5,6 @@ var isValidQueueItem = function (item) {
 };
 
 var createNew = function(client, queueStorage) {
-    queueStorage = queueStorage || require("./storage/null-play-queue");
     var roomQueues = {};
 
     var roomQueueFactory = function(room) {

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -4,12 +4,14 @@ var isValidQueueItem = function (item) {
     return item.data && item.duration && item.requester;
 };
 
-var roomQueueFactory = function() {
-    return roomQueue.new();
-};
-
-var createNew = function(client) {
+var createNew = function(client, queueStorage) {
+    queueStorage = queueStorage || require("./storage/null-play-queue");
     var roomQueues = {};
+
+    var roomQueueFactory = function(room) {
+        storage = queueStorage.new('room' + room);
+        return roomQueue.new(storage);
+    };
 
     var clearEmptyRooms = function () {
         Object.keys(roomQueues).filter(function (roomName) {
@@ -49,7 +51,7 @@ var createNew = function(client) {
             return false;
         }
         if (!roomQueues[room]) {
-            roomQueues[room] = roomQueueFactory();
+            roomQueues[room] = roomQueueFactory(room);
         }
         roomQueues[room].add(item);
         return true;

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -9,8 +9,17 @@ var createNew = function(client, queueStorage) {
     var roomQueues = {};
 
     var roomQueueFactory = function(room) {
-        var storage = queueStorage.new('room' + room);
+        var storage = queueStorage.new(room);
         return roomQueue.new(storage);
+    };
+
+    var loadPersistedQueues = function() {
+        queueStorage.loadAllRememberedQueues(function(individualStores) {
+            Object.keys(individualStores).forEach(function(roomName) {
+                roomQueues[roomName] = roomQueueFactory(roomName);
+                roomQueues[roomName].initFromStorage();
+            });
+        });
     };
 
     var clearEmptyRooms = function () {
@@ -59,7 +68,8 @@ var createNew = function(client, queueStorage) {
 
     setInterval(tick, 100);
     return {
-        "queueItem": queueItem
+        "queueItem": queueItem,
+        "loadPersistedQueues": loadPersistedQueues
     };
 };
 

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -13,8 +13,8 @@ var createNew = function(client, queueStorage) {
     };
 
     var loadPersistedQueues = function() {
-        queueStorage.loadAllRememberedQueues(function(individualStores) {
-            Object.keys(individualStores).forEach(function(roomName) {
+        queueStorage.loadAllRememberedQueues(function(roomNames) {
+            roomNames.forEach(function(roomName) {
                 roomQueues[roomName] = roomQueueFactory(roomName);
                 roomQueues[roomName].initFromStorage();
             });

--- a/lib/play-queue.js
+++ b/lib/play-queue.js
@@ -9,7 +9,7 @@ var createNew = function(client, queueStorage) {
     var roomQueues = {};
 
     var roomQueueFactory = function(room) {
-        storage = queueStorage.new('room' + room);
+        var storage = queueStorage.new('room' + room);
         return roomQueue.new(storage);
     };
 

--- a/lib/play-queue/room-queue.js
+++ b/lib/play-queue/room-queue.js
@@ -17,29 +17,41 @@ var createNew = function(storage) {
     var getAll = function () {
         return items;
     };
+
+    var deQueueNext = function (currentTime) {
+        playingItem = items[0];
+        playingItem.startTime = currentTime;
+        items = items.slice(1);
+    };
+
+    var livePlayResponse = function (currentTime) {
+        var currentOffset = currentTime - playingItem.startTime;
+        return {
+            "data": playingItem.data,
+            "requester": playingItem.requester,
+            "playOffset": currentOffset
+        };
+    };
+
+    var clearCurrent = function () {
+        playingItem = null;
+    };
+
     var tick = function(currentTime) {
-        // TODO: refactor the slightly complicated logic here
-        var currentOffset;
         if (playingItem) {
-            currentOffset = currentTime - playingItem.startTime;
+            var currentOffset = currentTime - playingItem.startTime;
             if (currentOffset > playingItem.duration + changeOverTime) {
-                playingItem = null;
+                clearCurrent();
             } else if(currentOffset > playingItem.duration) {
+                // This is the pause between songs.
                 return null;
             }
         }
         if (!playingItem && items.length > 0) {
-            playingItem = items[0];
-            playingItem.startTime = currentTime;
-            items = items.slice(1);
+            deQueueNext(currentTime);
         }
         if (playingItem) {
-            currentOffset = currentTime - playingItem.startTime;
-            return {
-                "data":       playingItem.data,
-                "requester":  playingItem.requester,
-                "playOffset": currentOffset
-            };
+            return livePlayResponse(currentTime);
         }
         return null;
     };

--- a/lib/play-queue/room-queue.js
+++ b/lib/play-queue/room-queue.js
@@ -2,7 +2,7 @@ var validItem = function(item) {
     return item.data && item.duration && item.requester;
 };
 
-var createNew = function() {
+var createNew = function(storage) {
     var items = [];
     var playingItem;
     var changeOverTime = 5000; // 5 seconds between tracks

--- a/lib/play-queue/room-queue.js
+++ b/lib/play-queue/room-queue.js
@@ -6,6 +6,16 @@ var createNew = function(storage) {
     var items = [];
     var playingItem;
     var changeOverTime = 5000; // 5 seconds between tracks
+    var loading = false;
+
+    var initFromStorage = function() {
+        loading = true;
+        storage.loadRememberQueueState(function(loadedCurrent, loadedItems){
+            playingItem = loadedCurrent;
+            items = loadedItems;
+            loading = false;
+        });
+    };
 
     var add = function (item) {
         if (!validItem(item)) {
@@ -61,10 +71,16 @@ var createNew = function(storage) {
         return null;
     };
 
+    var isEmpty = function () {
+        return !playingItem &&
+            items.length === 0 &&
+            !loading;
+    };
     return {
+        'initFromStorage': initFromStorage,
         'add'    : add,
         'getAll' : getAll,
-        'isEmpty': function() { return !playingItem && items.length === 0;},
+        'isEmpty': isEmpty,
         'tick'   : tick
     };
 };

--- a/lib/play-queue/room-queue.js
+++ b/lib/play-queue/room-queue.js
@@ -12,8 +12,10 @@ var createNew = function(storage) {
             return false;
         }
         items.push(item);
+        storage.storeQueueUpNext(items);
         return true;
     };
+
     var getAll = function () {
         return items;
     };
@@ -21,7 +23,9 @@ var createNew = function(storage) {
     var deQueueNext = function (currentTime) {
         playingItem = items[0];
         playingItem.startTime = currentTime;
+        storage.storeQueueCurrent(playingItem);
         items = items.slice(1);
+        storage.storeQueueUpNext(items);
     };
 
     var livePlayResponse = function (currentTime) {
@@ -35,6 +39,7 @@ var createNew = function(storage) {
 
     var clearCurrent = function () {
         playingItem = null;
+        storage.storeQueueCurrent(playingItem);
     };
 
     var tick = function(currentTime) {

--- a/lib/storage/loader.js
+++ b/lib/storage/loader.js
@@ -1,5 +1,9 @@
+var globalClient;
 var redisClientForEnv = function (env) {
-    return require('redis').createClient(env.REDIS_URL);
+    if (!globalClient) {
+        globalClient = require('redis').createClient(env.REDIS_URL);
+    }
+    return globalClient;
 };
 
 var loadMessageStore = function(env) {

--- a/lib/storage/loader.js
+++ b/lib/storage/loader.js
@@ -1,9 +1,5 @@
-var globalClient;
 var redisClientForEnv = function (env) {
-    if (!globalClient) {
-        globalClient = require('redis').createClient(env.REDIS_URL);
-    }
-    return globalClient;
+    return require('redis').createClient(env.REDIS_URL);
 };
 
 var loadMessageStore = function(env) {

--- a/lib/storage/loader.js
+++ b/lib/storage/loader.js
@@ -1,10 +1,14 @@
-var loadDataStore = function(env) {
+var redisClientForEnv = function (env) {
+    return require('redis').createClient(env.REDIS_URL);
+};
+
+var loadMessageStore = function(env) {
     var dataStore;
 
     // REDIS is the preferred option. Heroku will have the REDIS_URL
     // set if this is available.
     if (env.REDIS_URL) {
-        var client = require('redis').createClient(env.REDIS_URL);
+        var client = redisClientForEnv(env);
         var redisStorage = require('./redis-messages');
         dataStore = redisStorage.new(client, 30);
 
@@ -19,6 +23,22 @@ var loadDataStore = function(env) {
     return dataStore;
 };
 
+var loadPlayQueueStore = function(env) {
+    var dataStore;
+
+    // REDIS is the preferred option. Heroku will have the REDIS_URL
+    // set if this is available.
+    if (env.REDIS_URL) {
+        var client = redisClientForEnv(env);
+        dataStore = require('./redis-play-queue').start(client);
+        // If redis isn't available then don't persist queues
+    } else {
+        dataStore = require('./null-play-queue').start();
+    }
+    return dataStore;
+};
+
 module.exports = {
-    load: loadDataStore
+    loadMessageStore: loadMessageStore,
+    loadPlayQueueStore: loadPlayQueueStore
 };

--- a/lib/storage/null-play-queue.js
+++ b/lib/storage/null-play-queue.js
@@ -17,11 +17,8 @@ var start = function() {
     return {
         "new": CreatePlayQueueStorage,
         "loadAllRememberedQueues": function (callback) {
-            // much like john snow I know nothing
-            // {
-            //   "queue-name": queueStorage
-            // }
-            callback({});
+            // array of queue names remembered
+            callback([]);
         }
     };
 };

--- a/lib/storage/null-play-queue.js
+++ b/lib/storage/null-play-queue.js
@@ -1,11 +1,9 @@
 var CreatePlayQueueStorage = function(queueName) {
     return {
         storeQueueCurrent: function(current) {
-            console.log("remembering current");
             //forget it
         },
         storeQueueUpNext: function(upNext) {
-            console.log("remembering upnext");
             //forget it
         },
         loadRememberQueueState: function(callback) {

--- a/lib/storage/null-play-queue.js
+++ b/lib/storage/null-play-queue.js
@@ -1,0 +1,28 @@
+var CreatePlayQueueStorage = function(queueName) {
+    return {
+        storeQueueCurrent: function(current) {
+            console.log("remembering current");
+            //forget it
+        },
+        storeQueueUpNext: function(upNext) {
+            console.log("remembering upnext");
+            //forget it
+        },
+        loadRememberQueueState: function(callback) {
+            // again I know nothing
+            // state, queue
+            callback(null, []);
+        }
+    };
+};
+
+module.exports = {
+    "new": CreatePlayQueueStorage,
+    "getAllRememberedQueues": function (callback) {
+        // much like john snow I know nothing
+        // {
+        //   "queue-name": queueStorage
+        // }
+        callback({});
+    }
+};

--- a/lib/storage/null-play-queue.js
+++ b/lib/storage/null-play-queue.js
@@ -1,26 +1,31 @@
-var CreatePlayQueueStorage = function(queueName) {
+var start = function() {
+    var CreatePlayQueueStorage = function(queueName) {
+        return {
+            storeQueueCurrent: function(current) {
+                //forget it
+            },
+            storeQueueUpNext: function(upNext) {
+                //forget it
+            },
+            loadRememberQueueState: function(callback) {
+                // again I know nothing
+                // state, queue
+                callback(null, []);
+            }
+        };
+    };
     return {
-        storeQueueCurrent: function(current) {
-            //forget it
-        },
-        storeQueueUpNext: function(upNext) {
-            //forget it
-        },
-        loadRememberQueueState: function(callback) {
-            // again I know nothing
-            // state, queue
-            callback(null, []);
+        "new": CreatePlayQueueStorage,
+        "loadAllRememberedQueues": function (callback) {
+            // much like john snow I know nothing
+            // {
+            //   "queue-name": queueStorage
+            // }
+            callback({});
         }
     };
 };
 
 module.exports = {
-    "new": CreatePlayQueueStorage,
-    "loadAllRememberedQueues": function (callback) {
-        // much like john snow I know nothing
-        // {
-        //   "queue-name": queueStorage
-        // }
-        callback({});
-    }
+    "start": start
 };

--- a/lib/storage/null-play-queue.js
+++ b/lib/storage/null-play-queue.js
@@ -16,7 +16,7 @@ var CreatePlayQueueStorage = function(queueName) {
 
 module.exports = {
     "new": CreatePlayQueueStorage,
-    "getAllRememberedQueues": function (callback) {
+    "loadAllRememberedQueues": function (callback) {
         // much like john snow I know nothing
         // {
         //   "queue-name": queueStorage

--- a/lib/storage/redis-play-queue.js
+++ b/lib/storage/redis-play-queue.js
@@ -56,7 +56,7 @@ var start = function(redis) {
                     console.log(err);
                     return;
                 }
-                callback(Object.keys(data));
+                callback(Object.keys(data || {}));
             });
         }
     };

--- a/lib/storage/redis-play-queue.js
+++ b/lib/storage/redis-play-queue.js
@@ -1,0 +1,68 @@
+var start = function(redis) {
+    var redisPrefix = "playqueue-storage";
+    var ttl = 60 * 60; // store for an hour
+    var queueListKey = redisPrefix + "-allqueues";
+
+    var CreatePlayQueueStorage = function(queueName) {
+        var queueKey = redisPrefix + "-data-" + queueName;
+
+        var rememberQueueName = function() {
+            redis.hset(
+                queueListKey,
+                queueName,
+                "1"
+            );
+            redis.expire(queueKey, ttl);
+        };
+        return {
+            storeQueueCurrent: function(current) {
+                redis.hset(
+                    queueKey,
+                    'current',
+                    JSON.stringify(current)
+                );
+                redis.expire(queueKey, ttl);
+                rememberQueueName();
+            },
+            storeQueueUpNext: function(upNext) {
+                redis.hset(
+                    queueKey,
+                    'upnext',
+                    JSON.stringify(upNext)
+                );
+                redis.expire(queueKey, ttl);
+                rememberQueueName();
+            },
+            loadRememberQueueState: function(callback) {
+                redis.hgetall(queueKey, function (err, data) {
+                    if (err) {
+                        console.log(err);
+                        return;
+                    }
+                    callback(
+                        data.current || null,
+                        data.upnext || []
+                    );
+                });
+            }
+        };
+    };
+
+    return {
+        "new": CreatePlayQueueStorage,
+        "loadAllRememberedQueues": function (callback) {
+            redis.hgetall(queueListKey, function (err, data) {
+                if (err) {
+                    console.log(err);
+                    return;
+                }
+                callback(Object.keys(data));
+            });
+        }
+    };
+};
+
+
+module.exports = {
+    "start": start
+};

--- a/lib/storage/redis-play-queue.js
+++ b/lib/storage/redis-play-queue.js
@@ -39,10 +39,9 @@ var start = function(redis) {
                         console.log(err);
                         return;
                     }
-                    callback(
-                        data.current || null,
-                        data.upnext || []
-                    );
+                    var current = (data.current) ? JSON.parse(data.current) : null;
+                    var upnext = (data.upnext) ? JSON.parse(data.upnext) : [];
+                    callback(current, upnext);
                 });
             }
         };

--- a/lib/storage/redis-play-queue.js
+++ b/lib/storage/redis-play-queue.js
@@ -39,8 +39,8 @@ var start = function(redis) {
                         console.log(err);
                         return;
                     }
-                    var current = (data.current) ? JSON.parse(data.current) : null;
-                    var upnext = (data.upnext) ? JSON.parse(data.upnext) : [];
+                    var current = (data && data.current) ? JSON.parse(data.current) : null;
+                    var upnext = (data && data.upnext) ? JSON.parse(data.upnext) : [];
                     callback(current, upnext);
                 });
             }

--- a/spec/backend/play-queue/room-queue-spec.js
+++ b/spec/backend/play-queue/room-queue-spec.js
@@ -13,6 +13,7 @@ describe("A single room queue that updates when told what the time is", function
 
     beforeEach(function () {
         storage = require("../../../lib/storage/null-play-queue")
+            .start()
             .new('room-test');
         queue = roomQueue.new(storage);
 

--- a/spec/backend/play-queue/room-queue-spec.js
+++ b/spec/backend/play-queue/room-queue-spec.js
@@ -18,11 +18,13 @@ describe("A single room queue that updates when told what the time is", function
 
         spyOn(storage, 'storeQueueUpNext');
         spyOn(storage, 'storeQueueCurrent');
+        spyOn(storage, 'loadRememberQueueState');
     });
 
     afterEach(function() {
         storage.storeQueueUpNext.calls.reset();
         storage.storeQueueCurrent.calls.reset();
+        storage.loadRememberQueueState.calls.reset();
     });
 
     it("accepts items given to add", function() {
@@ -192,6 +194,13 @@ describe("A single room queue that updates when told what the time is", function
         queue.tick(startTime + pastFirstduration + 5001);
         expect(storage.storeQueueCurrent.calls.mostRecent().args)
             .toEqual([null]);
+
+    });
+
+    it("can be reset to a persisted state", function() {
+        queue.initFromStorage();
+        expect(storage.loadRememberQueueState.calls.count())
+            .toEqual(1);
 
     });
 


### PR DESCRIPTION
Fixes #101 

Similarly to our message persistence it checks if redis is available. If it is then it uses that to store the play queue (for up to an hour).  If redis isn't available then it switches off queue persistence.

I'd normally rebase smush these commits down a little but in case my thought process was useful I've left them as is/was.
